### PR TITLE
Fix set type bit order

### DIFF
--- a/sbe/__init__.py
+++ b/sbe/__init__.py
@@ -1054,7 +1054,7 @@ def _parse_schema(f: TextIO) -> Schema:
             elif action == "end":
                 x = stack.pop()
                 assert isinstance(stack[-1], Schema)
-                x.choices = sorted(x.choices, key=lambda y: int(y.value))
+                x.choices = sorted(x.choices, key=lambda y: int(y.value), reverse=True)
                 stack[-1].types[x.name] = x
 
         elif tag == "choice":


### PR DESCRIPTION
Python bistrings are processed MSB-first, but SBE set types are processed LSB first. Therefore, we need to reverse the encoding/decoding order as parsed.

This may need to be tested for sets which are larger than 1 byte