### PR TITLE
Fix handling of repeating groups with padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /dist/
 /sbe.egg-info/
 __pycache__/
+.venv
+.eggs

--- a/sbe/__init__.py
+++ b/sbe/__init__.py
@@ -758,8 +758,12 @@ def _walk_fields_encode(schema: Schema, fields: List[Union[Group, Field]],
                                     f.blockLength, Cursor(0))
                 if block_length is None:
                     block_length = struct.calcsize("<" + ''.join(fmt1))
+                    if f.blockLength:
+                        assert f.blockLength >= block_length
+                if f.blockLength and f.blockLength > block_length:
+                    fmt1.append(str(f.blockLength - block_length) + 'x')
 
-            dimension = {"numInGroup": len(obj[f.name]), "blockLength": block_length or f.blockLength or 0}
+            dimension = {"numInGroup": len(obj[f.name]), "blockLength": f.blockLength or block_length or 0}
             dimension_fmt = _pack_format(schema, f.dimensionType)
 
             fmt.extend(dimension_fmt)

--- a/tests/dat/example-schema.xml
+++ b/tests/dat/example-schema.xml
@@ -80,7 +80,7 @@
     </sbe:message>
     <sbe:message name="TestBlockLength" id="3" blockLength="4">
         <field name="year" id="1" type="ModelYear"/>
-        <group name="AGroup" id="2" dimensionType="groupSizeEncoding" blbockLength="6">
+        <group name="AGroup" id="2" dimensionType="groupSizeEncoding" blockLength="6">
             <field name="numbers" id="1" type="someNumbers"/>
         </group>
     </sbe:message>

--- a/tests/test_sbe.py
+++ b/tests/test_sbe.py
@@ -30,9 +30,10 @@ def test_blockLength():
                                                           {'numbers': 456}]})
         # BlockHeader = 8b
         # Body = 2b year + 2b padding
+        # GroupHeader = 4b
         # Repeating group = 2 * (4b numbers + 2b padding)
-        expLen = 8 + 4 + 2*6
-        assert len(encoded) == expLen, "Encoded SBE not padded properly"
+        expLen = 8 + 4 + 4 + 2*6
+        assert len(encoded) == expLen, f"Encoded SBE not padded properly. Expected {expLen} actual {len(encoded)}"
 
         decoded  = s.decode(encoded)
         assert decoded.value['year'] == 1990


### PR DESCRIPTION
- If the group specifies a blockLength greater than the calculated (natural) group size, we need to add padding after each group.
- The groupSizeEncoding must report the specified blockLength so the decoder can skip over padding.
- Fix a typo in the schema